### PR TITLE
Fix dynamic import error for make_dataset modules in editable installs

### DIFF
--- a/discobench/create_task.py
+++ b/discobench/create_task.py
@@ -1,7 +1,7 @@
 """A function so you can just import create_task and it will return make_files_public, make_files_private and task_description."""
 
 import argparse
-import os
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -33,9 +33,9 @@ def create_task(
 
     if config_path is None and config_dict is None:
         if example is True:
-            config_path = os.path.join(os.path.dirname(__file__), f"example_configs/{task_domain}.yaml")
+            config_path = str(Path(__file__).parent / f"example_configs/{task_domain}.yaml")
         else:
-            config_path = os.path.join(os.path.dirname(__file__), f"tasks/{task_domain}/task_config.yaml")
+            config_path = str(Path(__file__).parent / f"tasks/{task_domain}/task_config.yaml")
     if config_dict is not None:
         task_config = config_dict
     else:

--- a/discobench/utils/get_domains.py
+++ b/discobench/utils/get_domains.py
@@ -7,6 +7,6 @@ def get_domains() -> list[str]:
     Returns:
         List of [domains].
     """
-    task_path = pathlib.Path("discobench/tasks")
+    task_path = pathlib.Path(__file__).parent.parent / "tasks"
     domains = [p.name for p in task_path.iterdir()]
     return domains

--- a/discobench/utils/get_modules.py
+++ b/discobench/utils/get_modules.py
@@ -7,7 +7,7 @@ def get_modules() -> dict[str, list[str]]:
     Returns:
         Dictionary of {domain: modules}.
     """
-    task_path = pathlib.Path("discobench/tasks")
+    task_path = pathlib.Path(__file__).parent.parent / "tasks"
     module_dict = {}
     for task in task_path.iterdir():
         domain_path = task / "templates/default/base"


### PR DESCRIPTION
- Replace importlib.import_module() with importlib.util.spec_from_file_location() to load make_dataset modules directly from file paths
- fix issues with relative paths in create_task, get_domains and get_modules